### PR TITLE
Ajuste na rota ao clicar no botão deletar

### DIFF
--- a/src/app/components/book/list/list.component.ts
+++ b/src/app/components/book/list/list.component.ts
@@ -134,6 +134,7 @@ export class ListComponent implements OnInit {
 
   onCustom(event) {
     if (event.action === 'delete') {
+      // chamada do modal de confirmação antes de efetuar a ação do delete
       this.confirmationDialogService.confirm('Atenção!', 'Confirma a exclusão do Livro?')
         .then((confirmed) => {
           if (confirmed) {
@@ -145,8 +146,7 @@ export class ListComponent implements OnInit {
             });
           }
         });
-    }
-    if (event.action === 'donate') {
+    } else if (event.action === 'donate') {
       if (event.data.donated) {
         alert('Livro já doado!');
       } else {


### PR DESCRIPTION
Antes ao clicar no botão de deletar, mesmo com a modal por trás na pagina abria a pagina de edição do livro. Com a inclusão do else, agora ao clicar no botão aparece o modal, e não há mais a navegação na rota de edição do livro.