### PR TITLE
Inserindo frase de convite e ajuste de botão

### DIFF
--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -107,7 +107,14 @@
       </p>
 
       <a type="button" class="btn btn-primary" href='/livros/grimm---contos-para-sonhos-horripilantes'>Eu quero esse livro!</a>
-      &nbsp;
+
+      <br><br>
+      <p>
+        <strong>
+          Você é escritor e deseja estar no programa de destaque do Sharebook?
+        </strong> <br>
+          Então entre em contato através do link abaixo!
+        </p>
       <!-- Adição de botão para autores que queiram doar livro e ser autor destaque! -->
       <a type="button" class="btn btn-primary" href='/contact-us'>Eu quero ser Autor Destaque!</a>
   


### PR DESCRIPTION
Ajustando botão de convite para programa de autor destaque com uso de uma frase para convite.
Isso minimiza a questão dos botões grudarem um no outro em dispositivos mobile, e deixa mais formal e elegante o convite para os autores :)